### PR TITLE
fix: lua encode structural error

### DIFF
--- a/stored/internal/luajson/luajson.go
+++ b/stored/internal/luajson/luajson.go
@@ -115,7 +115,7 @@ func (j jsonValue) MarshalJSON() (data []byte, err error) {
 
 		switch key.Type() {
 		case lua.LTNil: // empty table
-			data = []byte(`[]`)
+			data = []byte(`null`)
 		case lua.LTNumber:
 			arr := make([]jsonValue, 0, converted.Len())
 			expectedKey := lua.LNumber(1)


### PR DESCRIPTION
# Ⅰ. Describe what this PR does
```
Pass an object to lua for modification, and the resulting return value. After serialization the field type changed. 
```

```
if not fix, the jsonBytes whill be 

 {"metadata":[],"spec":{"containers":[{"image":"centos:7","name":"centos","resources":[]}]},"status":[]}

```
- metadata
- status
- resources